### PR TITLE
expand clickable area in menu items

### DIFF
--- a/om17.css
+++ b/om17.css
@@ -75,8 +75,11 @@ footer {
 	margin: 10px 1em 1em 23px;
 }
 
+.site-title a {
+	padding: 13px 0;
+}
+
 .main-navigation li {
-	padding: 12px 20px 8px 20px;
 	margin-top: -10px;
 }
 
@@ -110,14 +113,15 @@ footer {
 .site-info a {
 	text-decoration: none;
 	color: black;
+	padding: 10px;
 }
 
 .site-info span {
-	line-height: 30px;
-	padding: 4px 10px;
 	border: 5px solid black;
 	border-top: none;
 	display: inline-block;
+	line-height: 30px;
+	padding: 4px 0;
 }
 
 .site-info .footer-right span:first-child {
@@ -149,11 +153,15 @@ footer {
 		right: 0;
 	}
 
+	.menu-item a {
+		padding: 12px 20px 8px 20px;
+	}
+
 	.menu-navigation-container li.menu-item,
 	.menu-main-nav-container li.menu-item {
 		float: none;
 		border-bottom: 5px solid black;
-		padding-top: 20px;
+		padding-top: 8px;
 	}
 
 	.menu-navigation-container,
@@ -185,18 +193,24 @@ footer {
 }
 
 @media screen and (min-width: 780px) {
-	.menu-item:hover {
-		border: 5px solid black;
-		border-bottom: none;
-		padding: 12px 15px 8px 15px;
-	}
-
-	.current-menu-item.menu-item:hover {
+	.menu-item a {
 		padding: 12px 20px 8px 20px;
 	}
 
-	.main-navigation .menu-item:hover > a {
-		margin-top: -5px;
+	.menu-item a:hover {
+		border: 5px solid black;
+		border-bottom: none;
+		padding: 7px 15px 8px 15px;
+	}
+
+	.current-menu-item.menu-item a {
+		padding: 12px 15px 8px 15px;
+	}
+
+	.current-menu-item.menu-item a:hover {
+		padding: 7px 15px 8px 15px;
+		border-left: none;
+		border-right: none;
 	}
 }
 


### PR DESCRIPTION
Ich habe die klickbaren Bereiche in den Menü-Buttons vergrößert (ohne die Buttons selbst zu vergrößern), weil ich häufig daneben geklickt habe. Getestet mit aktuellem Chromium und Firefox unter Ubuntu 16.04, Chrome unter Android 7.0, Chrome und Safari unter iOS 10.3.1.